### PR TITLE
Install and run trunk without using their github action

### DIFF
--- a/.github/workflows/build-py.yml
+++ b/.github/workflows/build-py.yml
@@ -16,13 +16,18 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Upgrade PIP ${{ matrix.python-version }}
+      - name: Upgrade PIP
         run: python -m pip install --upgrade pip
-      - name: Install dependencies ${{ matrix.python-version }}
+      - name: Install dependencies
         run: if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Trunk Check ${{ matrix.python-version }}
-        uses: trunk-io/trunk-action@v1
-        with:
-          arguments: --github-annotate-new-only=false
-      - name: Test with pytest ${{ matrix.python-version }}
+      - name: Install Trunk
+        run: |
+          mkdir .github/bin/
+          curl -fsSL https://trunk.io/releases/trunk -o .github/bin/trunk
+          chmod u+x .github/bin/trunk
+      - name: Trunk Check
+        run: |
+          git fetch origin HEAD
+          ./.github/bin/trunk check --all
+      - name: Test with pytest
         run: pytest


### PR DESCRIPTION
Using the vendor's github action kept failing with the cryptic error:

```log
  # Run trunk check on push
  ${GITHUB_ACTION_PATH}/push.sh
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.7.13/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.7.13/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.7.13/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.7.13/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.7.13/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.7.13/x64/lib
    TRUNK_TMPDIR: /tmp/tmp.bz1V1eFqB1
    TRUNK_PATH: /tmp/tmp.bz1V1eFqB1/trunk
    TRUNK_CHECK_MODE: push
    GITHUB_EVENT_AFTER: a165f6a191a83db115eca49395ee35b9f9542ceb
    GITHUB_EVENT_BEFORE: 0000000000000000000000000000000000000000
    GITHUB_REF_NAME: pr/kemitix/master/cf2fdb0b
    GITHUB_REPOSITORY: kemitix/gitzen
    GITHUB_TOKEN: ***
    INPUT_ARGUMENTS: --github-annotate-new-only=false
    INPUT_LABEL:
fatal: remote error: upload-pack: not our ref 0000000000000000000000000000000000000000
Error: Process completed with exit code 128.
```

commit-id:a17d8ec0

---

**Stack**:
- #14
- #15 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*