### PR TITLE
gz (and repo.getRoot()) abort when called outside a git repo

### DIFF
--- a/gitzen/repo.py
+++ b/gitzen/repo.py
@@ -5,8 +5,12 @@ from typing import Tuple
 from gitzen import git
 
 
+# will exit the program if called from outside a git repo
 def rootDir() -> str:
-    return git.revParse("--show-toplevel")[0]
+    output = git.revParse("--show-toplevel")
+    if output == "":
+        exit(1)
+    return output[0]
 
 
 def getLocalBranchName() -> str:

--- a/gz
+++ b/gz
@@ -2,9 +2,11 @@
 
 import sys
 
-from gitzen import status
+from gitzen import repo, status
 
 print("`git zen` - prototype")
+
+repo.rootDir()  # verifies that we are in a git repo or exits the program
 
 for i, arg in enumerate(sys.argv):
     if i != 1:


### PR DESCRIPTION
commit-id:284ced9f

---

**Stack**:
- #21
- #20
- #19 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*