### PR TITLE
Remove empty intermediate function get_local_commit_stack

### DIFF
--- a/gitzen/commands/push.py
+++ b/gitzen/commands/push.py
@@ -9,7 +9,7 @@ def push(gitGithubEnv: envs.GitGithubEnv, config: config.Config):
     print(f"remote branch: {config.remote}/{remote_branch}")
     git.rebase(gitGithubEnv.gitEnv, f"{config.remote}/{remote_branch}")
     branches.validate_not_remote_pr(local_branch)
-    commit_stack = repo.get_local_commit_stack(
+    commit_stack = repo.get_commit_stack(
         gitGithubEnv.gitEnv,
         config.remote,
         remote_branch,

--- a/gitzen/repo.py
+++ b/gitzen/repo.py
@@ -53,23 +53,6 @@ def get_repo_details_from_remote(remote: str) -> Tuple[str, str, str, bool]:
     return "", "", "", False
 
 
-def get_local_commit_stack(
-    git_env: envs.GitEnv,
-    remote: str,
-    remote_branch: str,
-) -> List[Commit]:
-    commit_log = get_commit_stack(git_env, remote, remote_branch)
-    # TODO
-    return commit_log
-
-
-#     # parse logStack to get commits and check if valid
-#     # if not valid then
-#         # rebase and add custom tags
-#         # do logCommand again and parse logStack
-#         # if still not valid - abort - panic!
-
-
 def get_commit_stack(
     git_env: envs.GitEnv,
     remote: str,


### PR DESCRIPTION
Its original purpose was to rebase and try again of the first attempt
failed, i.e. found missing zen-tokens. However, push has already done
a rebase, so doing so again here would be pointless.

commit-id:f95884b0