### PR TITLE
workflow,pre-commit: run high value tests first

### DIFF
--- a/.github/workflows/build-py.yml
+++ b/.github/workflows/build-py.yml
@@ -20,20 +20,22 @@ jobs:
         run: python -m pip install --upgrade pip
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements_dev.txt
+
+      - name: Pyre Check
+        run: pyre --sequential check
+      - name: Pytest
+        run: pytest -vv
+
       - name: Install Trunk
         run: |
           mkdir .github/bin/
           curl -fsSL https://trunk.io/releases/trunk -o .github/bin/trunk
           chmod u+x .github/bin/trunk
+      - name: Fetch Git History for Trunk
+        run: git fetch origin HEAD
       - name: Install Trunk linters
         run: ./.github/bin/trunk install --ci
-      - name: Fetch Git History
-        run: git fetch origin HEAD
       - name: Trunk Verify Formatting
         run: ./.github/bin/trunk fmt --ci --all
       - name: Trunk Check
         run: ./.github/bin/trunk check --ci --all
-      - name: Pyre Check
-        run: pyre --sequential check
-      - name: Pytest
-        run: pytest -vv

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -2,14 +2,14 @@
 
 set -e
 
-echo -e "\n> trunk fmt"
-trunk fmt --ci
-echo -e "\n>trunk check"
-trunk check --ci
 echo -e "\n> pyre infer"
 pyre infer --in-place --annotate-attributes
 echo -e "\n> pyre check"
 pyre check
 echo -e "\n> pytest"
 pytest --cov=. --cov-branch --cov-report=xml
+echo -e "\n> trunk fmt"
+trunk fmt --ci
+echo -e "\n>trunk check"
+trunk check --ci
 echo -e "\n< Done\n"


### PR DESCRIPTION
Formatting tests are pushed to last as they are trivial fixes, while
bringing type-consistency and tests to the front for quicker
feedback. Quicker as the requirements for trunk take a time to
install, so don't do that if there are more important problems to be
fixed first..

commit-id:1ea0675b

---

**Stack**:
- #211
- #210
- #209
- #208
- #207 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*